### PR TITLE
fix security vulnerability

### DIFF
--- a/src/main/java/io/randomfiles/api/service/xml/XMLService.java
+++ b/src/main/java/io/randomfiles/api/service/xml/XMLService.java
@@ -17,6 +17,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.XMLConstants;
 import java.io.ByteArrayOutputStream;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/io/randomfiles/api/service/xml/XMLService.java
+++ b/src/main/java/io/randomfiles/api/service/xml/XMLService.java
@@ -64,6 +64,7 @@ public class XMLService {
 
     private void transformToXMLString(ByteArrayOutputStream byteArrayOutputStream, Document xmlDocument) throws TransformerException {
         TransformerFactory transformerFactory = TransformerFactory.newInstance();
+        transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         Transformer transformer = transformerFactory.newTransformer();
         transformer.setOutputProperty(OutputKeys.INDENT, "yes");
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount"


### PR DESCRIPTION
An XML External Entity or XSLT External Entity (XXE) vulnerability can occur when a javax.xml.transform.Transformer is created without enabling "Secure Processing" or when one is created without disabling resolving of both external DTDs and DTD entities. If that external data is being controlled by an attacker it may lead to the disclosure of confidential data, denial of service, server side request forgery, port scanning from the perspective of the machine where the parser is located, and other system impacts.