### PR TITLE
Disable XML external entity (XXE) processing.

### DIFF
--- a/src/main/java/io/randomfiles/api/service/xml/XMLService.java
+++ b/src/main/java/io/randomfiles/api/service/xml/XMLService.java
@@ -40,6 +40,7 @@ public class XMLService {
     public ByteArrayOutputStream generateXML() throws ParserConfigurationException, TransformerException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        documentBuilderFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         Document xmlDocument = documentBuilder.newDocument();
         Element rootElement = xmlDocument.createElement("randomXML");

--- a/src/main/java/io/randomfiles/api/service/xml/XMLService.java
+++ b/src/main/java/io/randomfiles/api/service/xml/XMLService.java
@@ -40,7 +40,7 @@ public class XMLService {
     public ByteArrayOutputStream generateXML() throws ParserConfigurationException, TransformerException {
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
-        documentBuilderFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, Boolean.FALSE);
+        documentBuilderFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         Document xmlDocument = documentBuilder.newDocument();
         Element rootElement = xmlDocument.createElement("randomXML");


### PR DESCRIPTION
Allowing external DTD entities in untrusted documents to be processed could lay your systems bare to attackers.